### PR TITLE
fix set_main_vcl()

### DIFF
--- a/fastly/__init__.py
+++ b/fastly/__init__.py
@@ -899,7 +899,7 @@ class FastlyConnection(object):
 
 	def set_main_vcl(self, service_id, version_number, name):
 		"""Set the specified VCL as the main."""
-		content = self._fetch("/service/%s/version/%d/vcl/%s/main" % (service_id, version_number, name_key), method="PUT", body=body)
+		content = self._fetch("/service/%s/version/%d/vcl/%s/main" % (service_id, version_number, name), method="PUT")
 		return FastlyVCL(self, content)
 
 


### PR DESCRIPTION
Fastly's vcl/main api method doesn't take a request body (which is undefined here), and name_key is also undefined.
