### PR TITLE
Add convenience functions for header.{destination,source}

### DIFF
--- a/fastly/__init__.py
+++ b/fastly/__init__.py
@@ -1347,6 +1347,15 @@ class FastlyHeader(FastlyObject, IServiceVersionObject):
 		"cache_condition",
 	]
 
+	@property
+	def destination(self):
+		return self.dst
+
+	@property
+	def source(self):
+		return self.src
+
+
 
 class FastlyHealthCheck(FastlyObject, IServiceVersionObject):
 	"""Healthchecks are used to customize the way Fastly checks on your Backends. Only Backends that have successful Healthchecks will be sent traffic, thus assuring that the failure of one server does not affect visitors."""


### PR DESCRIPTION
This allows roundtripping through the API where you can use the fields
returned by the API to give as parameters to {create,update}_header.
