### PR TITLE
use Fastly-Key instead of X-Fastly-Key

### DIFF
--- a/fastly/__init__.py
+++ b/fastly/__init__.py
@@ -1057,7 +1057,7 @@ class FastlyConnection(object):
 		if self._fully_authed:
 			hdrs["Cookie"] = self._session
 		else:
-			hdrs["X-Fastly-Key"] = self._api_key
+			hdrs["Fastly-Key"] = self._api_key
 
 		hdrs["Content-Accept"] = "application/json"
 		if not hdrs.has_key("Content-Type") and method in ["POST", "PUT"]:


### PR DESCRIPTION
The use of `X-Fastly-Key` is deprecated and will not be supported long term. This branch replaces any occurrences of `X-Fastly-Key` with `Fastly-Key`.
