### PR TITLE
Update to correct Fastly-Key header for API tokens and API Keys

### DIFF
--- a/fastly/__init__.py
+++ b/fastly/__init__.py
@@ -1057,7 +1057,7 @@ class FastlyConnection(object):
 		if self._fully_authed:
 			hdrs["Cookie"] = self._session
 		else:
-			hdrs["X-Fastly-Key"] = self._api_key
+			hdrs["Fastly-Key"] = self._api_key
 
 		hdrs["Content-Accept"] = "application/json"
 		if not hdrs.has_key("Content-Type") and method in ["POST", "PUT"]:


### PR DESCRIPTION
It looks like Fastly has changed the expected header from `X-Fastly-Key` to simply `Fastly-Key`. See [their docs](https://docs-next.fastly.com/api/auth) for more details.